### PR TITLE
Add initial Terraform Azure infrastructure

### DIFF
--- a/terraform/modules/bastion/main.tf
+++ b/terraform/modules/bastion/main.tf
@@ -1,0 +1,20 @@
+resource "azurerm_public_ip" "bastion_pip" {
+  name                = "bastion-pip"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_bastion_host" "bastion" {
+  name                = "bastion-host"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  dns_name            = "bastion-demo"
+
+  ip_configuration {
+    name                 = "bastion-ipconfig"
+    subnet_id            = var.bastion_subnet_id
+    public_ip_address_id = azurerm_public_ip.bastion_pip.id
+  }
+}

--- a/terraform/modules/bastion/variables.tf
+++ b/terraform/modules/bastion/variables.tf
@@ -1,0 +1,3 @@
+variable "resource_group_name" {}
+variable "location" {}
+variable "bastion_subnet_id" {}

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -1,0 +1,20 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = var.vnet_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  address_space       = [var.vnet_address_space]
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = var.subnet_name
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [var.subnet_address_space]
+}
+
+resource "azurerm_subnet" "bastion_subnet" {
+  name                 = var.bastion_subnet_name
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = var.vnet_name
+  address_prefixes     = [var.bastion_subnet_address_space]
+}

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -1,0 +1,3 @@
+output "subnet_id" {
+  value = azurerm_subnet.subnet.id
+}

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -1,0 +1,18 @@
+variable "resource_group_name" {}
+variable "location" {}
+variable "vnet_name" {}
+variable "vnet_address_space" {}
+variable "subnet_name" {}
+variable "subnet_address_space" {}
+
+variable "bastion_subnet_name" {
+  description = "The name of the Azure Bastion subnet."
+  type        = string
+  default     = "AzureBastionSubnet"
+}
+
+variable "bastion_subnet_address_space" {
+  description = "The address space for the Azure Bastion subnet."
+  type        = string
+  default     = "10.0.2.0/27"
+}

--- a/terraform/modules/nsg/main.tf
+++ b/terraform/modules/nsg/main.tf
@@ -1,0 +1,41 @@
+resource "azurerm_network_security_group" "nsg" {
+  name                = "nsg-demo"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  security_rule {
+    name                      = "SSH-from-Bastion"
+    priority                  = 100
+    direction                 = "Inbound"
+    access                    = "Allow"
+    protocol                  = "Tcp"
+    source_address_prefix      = var.bastion_subnet_address_prefix
+    source_port_range          = "*"
+    destination_address_prefix = "*"
+    destination_port_range     = "22"
+  }
+
+  security_rule {
+    name                       = "HTTP"
+    priority                   = 101
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_address_prefix       = "*"
+    source_port_range           = "*"
+    destination_address_prefix  = "*"
+    destination_port_range      = "80"
+  }
+
+  security_rule {
+    name                        = "DenyAllOtherInbound"
+    priority                    = 200
+    direction                   = "Inbound"
+    access                      = "Deny"
+    protocol                    = "*"
+    source_address_prefix       = "*"
+    source_port_range           = "*"
+    destination_address_prefix  = "*"
+    destination_port_range      = "*"
+  }
+}

--- a/terraform/modules/nsg/outputs.tf
+++ b/terraform/modules/nsg/outputs.tf
@@ -1,0 +1,3 @@
+output "nsg_id" {
+  value = azurerm_network_security_group.nsg.id
+}

--- a/terraform/modules/nsg/variables.tf
+++ b/terraform/modules/nsg/variables.tf
@@ -1,0 +1,9 @@
+variable "resource_group_name" {}
+variable "location" {}
+variable "nsg_name" {}
+
+variable "bastion_subnet_address_prefix" {
+  description = "The address prefix for the Bastion subnet."
+  type        = string
+  default     = "10.0.2.0/27"
+}

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -1,0 +1,22 @@
+resource "azurerm_resource_group" "rg" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_storage_account" "sa" {
+  name                     = var.storage_account_name
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "dev"
+  }
+}
+
+resource "azurerm_storage_container" "container" {
+  name                  = var.container_name
+  storage_account_id    = azurerm_storage_account.sa.id
+  container_access_type = "private"
+}

--- a/terraform/modules/storage/outputs.tf
+++ b/terraform/modules/storage/outputs.tf
@@ -1,0 +1,11 @@
+output "storage_account_name" {
+  value = azurerm_storage_account.sa.name
+}
+
+output "container_name" {
+  value = azurerm_storage_container.container.name
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -1,0 +1,16 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+  default = "East US"
+}
+
+variable "storage_account_name" {
+  type = string
+}
+
+variable "container_name" {
+  type = string
+}

--- a/terraform/modules/vm/main.tf
+++ b/terraform/modules/vm/main.tf
@@ -1,0 +1,46 @@
+resource "azurerm_network_interface" "nic" {
+  name                = "${var.vm_name}-nic"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  ip_configuration {
+    name                          = "internal"
+    private_ip_address_allocation = "Dynamic"
+    private_ip_address_version    = "IPv4"
+    subnet_id                     = var.subnet_id
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "nic_nsg" {
+  network_interface_id      = azurerm_network_interface.nic.id
+  network_security_group_id = var.nsg_id
+}
+
+resource "azurerm_linux_virtual_machine" "vm" {
+  name                            = "vm-demo"
+  resource_group_name             = var.resource_group_name
+  location                        = var.location
+  size                            = var.vm_size
+  admin_username                  = "azureuser"
+  disable_password_authentication = true
+  provision_vm_agent              = true
+
+  network_interface_ids = [azurerm_network_interface.nic.id]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = file(var.ssh_public_key)
+  }
+}

--- a/terraform/modules/vm/outputs.tf
+++ b/terraform/modules/vm/outputs.tf
@@ -1,0 +1,7 @@
+output "vm_id" {
+  value = azurerm_linux_virtual_machine.vm.id
+}
+
+output "vm_public_ip" {
+  value = azurerm_network_interface.nic.private_ip_address
+}

--- a/terraform/modules/vm/variables.tf
+++ b/terraform/modules/vm/variables.tf
@@ -1,0 +1,41 @@
+variable "vm_name" {
+  description = "Name of the VM"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group name"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure location"
+  type        = string
+}
+
+variable "vm_size" {
+  description = "VM size"
+  type        = string
+  default     = "Standard_B1s"
+}
+
+variable "admin_username" {
+  description = "Admin username"
+  type        = string
+  default     = "azureuser"
+}
+
+variable "ssh_public_key" {
+  description = "Path to SSH public key"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID where the VM will be deployed"
+  type        = string
+}
+
+variable "nsg_id" {
+  description = "Network Security Group ID for the VM"
+  type        = string
+}

--- a/terraform/state-storage/main.tf
+++ b/terraform/state-storage/main.tf
@@ -1,0 +1,12 @@
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+module "storage" {
+  source                = "../modules/storage"
+  resource_group_name   = var.resource_group_name
+  location              = var.location
+  storage_account_name  = var.storage_account_name
+  container_name        = var.container_name
+}

--- a/terraform/state-storage/variables.tf
+++ b/terraform/state-storage/variables.tf
@@ -1,0 +1,27 @@
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+  default     = null
+}
+
+variable "resource_group_name" {
+  type = string
+  description = "The name of the resource group."
+}
+
+variable "location" {
+  type = string
+  description = "The location where resources will be created."
+}
+
+variable "storage_account_name" {
+  type = string
+  description = "The name of the storage account."
+  default = "tfstatestoragetc2025"
+}
+
+variable "container_name" {
+  type = string
+  description = "The name of the container within the storage account."
+  default = "tfstate"
+}

--- a/terraform/state-storage/versions.tf
+++ b/terraform/state-storage/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.80.0"
+    }
+  }
+}

--- a/terraform/vm-stack/backend.tf
+++ b/terraform/vm-stack/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "azurerm" {}
+}

--- a/terraform/vm-stack/main.tf
+++ b/terraform/vm-stack/main.tf
@@ -1,0 +1,33 @@
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+module "networking" {
+  source               = "../modules/networking"
+  resource_group_name  = var.resource_group_name
+  location             = var.location
+  vnet_name            = var.vnet_name
+  vnet_address_space   = var.vnet_address_space
+  subnet_name          = var.subnet_name
+  subnet_address_space = var.subnet_address_space
+}
+
+module "nsg" {
+  source              = "../modules/nsg"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  nsg_name            = var.nsg_name
+}
+
+module "vm" {
+  source              = "../modules/vm"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  vm_name             = var.vm_name
+  vm_size             = var.vm_size
+  admin_username      = var.admin_username
+  subnet_id           = module.networking.subnet_id
+  nsg_id              = module.nsg.nsg_id
+  ssh_public_key      = var.ssh_public_key
+}

--- a/terraform/vm-stack/outputs.tf
+++ b/terraform/vm-stack/outputs.tf
@@ -1,0 +1,22 @@
+# Virtual Machine outputs
+output "vm_id" {
+  description = "The ID of the virtual machine."
+  value       = module.vm.vm_id
+}
+
+output "vm_private_ip" {
+  description = "The private IP of the virtual machine."
+  value       = module.vm.vm_public_ip
+}
+
+# Networking outputs
+output "subnet_id" {
+  description = "The ID of the subnet created for the VM."
+  value       = module.networking.subnet_id
+}
+
+# NSG outputs
+output "nsg_id" {
+  description = "The ID of the network security group attached to the VM."
+  value       = module.nsg.nsg_id
+}

--- a/terraform/vm-stack/variables.tf
+++ b/terraform/vm-stack/variables.tf
@@ -1,0 +1,69 @@
+# General
+variable "location" {
+  type    = string
+  default = "East US"
+}
+
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+  default     = null
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The name of the resource group."
+}
+
+# Virtual Network
+variable "vnet_name" {
+  type    = string
+  default = "vnet-demo"
+}
+
+variable "vnet_address_space" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "subnet_name" {
+  type    = string
+  default = "subnet-demo"
+}
+
+variable "subnet_address_space" {
+  type    = string
+  default = "10.0.1.0/24"
+}
+
+# Network Security Group
+variable "nsg_name" {
+  type    = string
+  default = "nsg-demo"
+}
+
+# Virtual Machine
+variable "vm_name" {
+  type    = string
+  default = "vm-demo"
+}
+
+variable "vm_size" {
+  type    = string
+  default = "Standard_B1s"
+}
+
+variable "admin_username" {
+  type    = string
+  default = "azureuser"
+}
+
+variable "admin_password" {
+  type    = string
+  default = "P@ssw0rd1234!"
+}
+
+variable "ssh_public_key" {
+  type    = string
+  default = "~/.ssh/id_rsa.pub"
+}

--- a/terraform/vm-stack/versions.tf
+++ b/terraform/vm-stack/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.80.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the initial Terraform setup for provisioning Azure infrastructure for the demo environment.  

### Infrastructure included:

- **Virtual Network (VNet)** with:
  - VM subnet
  - Bastion subnet for secure SSH access
- **Network Security Group (NSG)**:
  - SSH allowed only from Bastion subnet
  - HTTP allowed from the internet
  - All other inbound traffic denied
- **Linux Virtual Machine**:
  - SSH key authentication
  - Password login disabled
- **Storage account** and **resource group** for Terraform state